### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/githubactions/back_01.yaml
+++ b/githubactions/back_01.yaml
@@ -36,7 +36,7 @@ jobs:
   
       
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: bugoga/tomat
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/githubactions/front_01.yaml
+++ b/githubactions/front_01.yaml
@@ -46,7 +46,7 @@ jobs:
       run: mv ${{ steps.write_privkey.outputs.filePath }} ./conf
     
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: bugoga/noginsk
         username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore